### PR TITLE
Update pins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,20 +9,20 @@ source:
   sha256: a26145b8ce43d2d934b3c6826d77b913ce105c528eb2e494c890b3e3525ddf33
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=2.7
+    - python >=3.6
     - param
     - pip
     - jupyter-packaging
     - jupyterlab
     - notebook
   run:
-    - python >=2.7
+    - python >=3.6
     - param
 
 test:


### PR DESCRIPTION
This PR updates the Python pin from >= 2.7 to >= 3.6.

pyviz_comms pin these build dependencies in its `setup.py` file, but not in its pyproject.toml file. There's some cleaning up to do on the project itself, but whatever is pinned there should ideally also be pinned in the recipe.
```
extras_require = {
    'tests': ['flake8', 'pytest'],
    'build': [
        'setuptools>=40.8.0,<61',
        'jupyterlab ~=3.0',
        'jupyter-packaging ~=0.7.9',
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
